### PR TITLE
[addConnectorForInitialisationCall] Add connector and httpParser for Initialisation call

### DIFF
--- a/app/connectors/UploadCustomsDocumentsConnector.scala
+++ b/app/connectors/UploadCustomsDocumentsConnector.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.AppConfig
+import connectors.httpParsers.UploadCustomsDocumentsInitializationHttpParser.{UploadCustomsDocumentsInitializationReads, UploadCustomsDocumentsInitializationResponse}
+import play.api.i18n.MessagesApi
+import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import utils.LoggerUtil
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class UploadCustomsDocumentsConnector @Inject()(httpClient: HttpClient, implicit val appConfig: AppConfig) extends LoggerUtil {
+
+  //TODO: Pass through a model representing all the configurable parameters
+  def initialize(configuration: JsValue)
+                (implicit hc: HeaderCarrier, ec: ExecutionContext, messages: MessagesApi): Future[UploadCustomsDocumentsInitializationResponse] = {
+    logger.debug(s"URL: ${appConfig.uploadCustomsDocumentsUrl}, Body: \n\n${Json.toJson(configuration)}")
+    httpClient.POST(
+      url = appConfig.uploadCustomsDocumentsUrl,
+      body = configuration
+    )(implicitly, UploadCustomsDocumentsInitializationReads, hc, ec)
+  }
+}

--- a/app/connectors/httpParsers/UploadCustomsDocumentsInitializationHttpParser.scala
+++ b/app/connectors/httpParsers/UploadCustomsDocumentsInitializationHttpParser.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.httpParsers
+
+import play.api.http.HeaderNames
+import play.api.http.Status._
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import utils.LoggerUtil
+
+object UploadCustomsDocumentsInitializationHttpParser extends LoggerUtil {
+
+  type UploadCustomsDocumentsInitializationResponse = Either[ErrorResponse, String]
+
+  implicit object UploadCustomsDocumentsInitializationReads extends HttpReads[UploadCustomsDocumentsInitializationResponse] {
+
+    def read(method: String, url: String, response: HttpResponse): UploadCustomsDocumentsInitializationResponse = {
+      response.status match {
+        case CREATED =>
+          response.header(HeaderNames.LOCATION) match {
+            case Some(url) => Right(url)
+            case None =>
+              logger.debug(s"[read]: No Location Header in response: ${response.headers}")
+              logger.warn(s"[read]: No Location Header returned from Upload Customs Documents Frontend")
+              Left(NoLocationHeaderReturned)
+          }
+        case status =>
+          logger.warn(s"[read]: Unexpected response, status $status returned")
+          Left(UnexpectedFailure(status))
+      }
+    }
+  }
+
+  trait ErrorResponse {
+    val status: Int
+    val body: String
+  }
+
+  object NoLocationHeaderReturned extends ErrorResponse {
+    override val status: Int = INTERNAL_SERVER_ERROR
+    override val body: String = "Upload Customs Documents Frontend returned CREATED (201) but did not provide a Location header"
+  }
+  case class UnexpectedFailure(override val status: Int) extends ErrorResponse {
+    override val body: String = s"Unexpected response, status $status returned"
+  }
+
+}

--- a/app/utils/LoggerUtil.scala
+++ b/app/utils/LoggerUtil.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.{LoggerLike, MarkerContext}
+
+trait LoggerUtil {
+
+  lazy val className: String = this.getClass.getSimpleName.stripSuffix("$")
+
+  val logger = new LoggerLike {
+
+    private lazy val prefixLog: String => String = s"[$className] " + _
+    override val logger: Logger = LoggerFactory.getLogger(s"application.$className")
+
+    override def debug(message: => String)(implicit mc: MarkerContext): Unit = super.debug(prefixLog(message))
+    override def info(message: => String)(implicit mc: MarkerContext): Unit = super.info(prefixLog(message))
+    override def warn(message: => String)(implicit mc: MarkerContext): Unit = super.warn(prefixLog(message))
+    override def error(message: => String)(implicit mc: MarkerContext): Unit = super.error(prefixLog(message))
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,6 +61,12 @@ microservice {
       host = localhost
       port = 9250
     }
+
+    upload-customs-documents-frontend {
+      protocol = http
+      host = localhost
+      port = 10110
+    }
   }
 }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,9 +12,10 @@ object AppDependencies {
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-28"     % "5.21.0"             % "test, it",
+    "uk.gov.hmrc"             %% "bootstrap-test-play-28"     % "5.21.0"            % "test, it",
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28"    % "0.62.0"            % Test,
     "org.jsoup"               %  "jsoup"                      % "1.13.1"            % Test,
-    "com.vladsch.flexmark"    %  "flexmark-all"               % "0.36.8"            % "test, it"
+    "com.vladsch.flexmark"    %  "flexmark-all"               % "0.36.8"            % "test, it",
+    "org.scalamock"           %% "scalamock"                  %  "5.1.0"            % Test
   )
 }

--- a/test/base/GuicySpec.scala
+++ b/test/base/GuicySpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import config.AppConfig
+import org.scalatestplus.play.guice._
+import play.api.Application
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.inject.{Injector, bind}
+import play.api.mvc.MessagesControllerComponents
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import scala.concurrent.ExecutionContext
+
+trait GuicySpec extends SpecBase with GuiceOneAppPerSuite {
+
+  override lazy val app: Application = GuiceApplicationBuilder().build()
+
+  lazy val injector: Injector = app.injector
+
+  implicit lazy val appConfig: AppConfig = injector.instanceOf[AppConfig]
+  implicit lazy val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
+  lazy val messagesControllerComponents: MessagesControllerComponents = injector.instanceOf[MessagesControllerComponents]
+  implicit lazy val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(fakeRequest)
+}

--- a/test/base/MaterializerSupport.scala
+++ b/test/base/MaterializerSupport.scala
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-package config
+package base
 
-import play.api.Configuration
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import akka.actor.ActorSystem
+import akka.stream.Materializer
 
-import javax.inject.{Inject, Singleton}
-
-@Singleton
-class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig) {
-
-  val welshLanguageSupportEnabled: Boolean = config.getOptional[Boolean]("features.welsh-language-support").getOrElse(false)
-
-  val uploadCustomsDocumentsUrl: String = servicesConfig.baseUrl("upload-customs-documents-frontend")
-
+trait MaterializerSupport {
+  implicit val system = ActorSystem("Sys")
+  implicit val materializer = Materializer(system)
 }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.{Assertion, BeforeAndAfterEach, TryValues}
+import org.scalatestplus.play.PlaySpec
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.CSRFTokenHelper._
+import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
+import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
+
+import scala.concurrent.duration.{Duration, FiniteDuration, _}
+import scala.concurrent.{Await, Future}
+
+trait SpecBase extends PlaySpec with TryValues with
+  ScalaFutures with IntegrationPatience with MaterializerSupport with BeforeAndAfterEach with FutureAwaits with DefaultAwaitTimeout {
+
+  private def makeFakeRequest(sessionKvs: (String, String)*) = {
+    val session: Seq[(String, String)] = sessionKvs.toSeq :+ SessionKeys.sessionId -> "foo"
+    FakeRequest("GET", "/foo").withSession(session: _*).withCSRFToken.asInstanceOf[FakeRequest[AnyContentAsEmpty.type]]
+  }
+
+  def fakeRequest(sessionKvs: (String, String)*): FakeRequest[AnyContentAsEmpty.type] = makeFakeRequest(sessionKvs: _*)
+
+  lazy val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = makeFakeRequest()
+
+  implicit val defaultTimeout: FiniteDuration = 5.seconds
+
+  def await[A](future: Future[A])(implicit timeout: Duration): A = Await.result(future, timeout)
+
+  implicit lazy val hc: HeaderCarrier = HeaderCarrier()
+
+  implicit class LogCapturingExtensions(logs: List[ILoggingEvent]) {
+    def includes(msg: String): Assertion = {
+      logs.map(_.getMessage).mkString("\n") must include(msg)
+    }
+  }
+}

--- a/test/connectors/UploadCustomsDocumentsConnectorSpec.scala
+++ b/test/connectors/UploadCustomsDocumentsConnectorSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import base.GuicySpec
+import connectors.httpParsers.UploadCustomsDocumentsInitializationHttpParser.NoLocationHeaderReturned
+import connectors.mocks.MockHttp
+import play.api.libs.json.Json
+
+class UploadCustomsDocumentsConnectorSpec extends GuicySpec with MockHttp {
+
+  val locationHeaderUrl = "/foo"
+  val dummyJson = Json.obj("foo" -> "bar")
+
+  object TestUploadCustomsDocumentsConnector extends UploadCustomsDocumentsConnector(mockHttp, appConfig)
+
+  "UploadCustomsDocumentsConnector" must {
+
+    "For the .initialise() method" must {
+
+      "for a successful response" must {
+
+        "return a Right(ValidClaimPeriodModel)" in {
+
+          setupMockHttpPost(appConfig.uploadCustomsDocumentsUrl, dummyJson)(Right(locationHeaderUrl))
+
+          val expectedResult = Right(locationHeaderUrl)
+          val actualResult = TestUploadCustomsDocumentsConnector.initialize(dummyJson)(hc, ec, messagesApi)
+
+          await(actualResult) mustBe expectedResult
+        }
+      }
+
+      "for an error response" must {
+
+        "return a Left(Invalid)" in {
+
+          setupMockHttpPost(appConfig.uploadCustomsDocumentsUrl, dummyJson)(Left(NoLocationHeaderReturned))
+
+          val expectedResult = Left(NoLocationHeaderReturned)
+          val actualResult = TestUploadCustomsDocumentsConnector.initialize(dummyJson)(hc, ec, messagesApi)
+
+          await(actualResult) mustBe expectedResult
+        }
+      }
+    }
+  }
+}

--- a/test/connectors/UploadCustomsDocumentsConnectorSpec.scala
+++ b/test/connectors/UploadCustomsDocumentsConnectorSpec.scala
@@ -34,7 +34,7 @@ class UploadCustomsDocumentsConnectorSpec extends GuicySpec with MockHttp {
 
       "for a successful response" must {
 
-        "return a Right(ValidClaimPeriodModel)" in {
+        "return a Right(locationHeaderUrl)" in {
 
           setupMockHttpPost(appConfig.uploadCustomsDocumentsUrl, dummyJson)(Right(locationHeaderUrl))
 

--- a/test/connectors/httpParsers/UploadCustomsDocumentsInitializationHttpParserSpec.scala
+++ b/test/connectors/httpParsers/UploadCustomsDocumentsInitializationHttpParserSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.httpParsers
+
+import base.SpecBase
+import connectors.httpParsers.UploadCustomsDocumentsInitializationHttpParser.{NoLocationHeaderReturned, UnexpectedFailure, UploadCustomsDocumentsInitializationReads}
+import play.api.http.{HeaderNames, Status}
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.HttpResponse
+
+class UploadCustomsDocumentsInitializationHttpParserSpec extends SpecBase {
+
+  "UploadCustomsDocumentsInitializationHttpParser.UploadCustomsDocumentsInitializationReads" when {
+
+    "given an (201) CREATED" when {
+
+      "the Location header is returned" must {
+
+        "return url" in {
+
+          val expectedResult = Right("/foo")
+          val actualResult = UploadCustomsDocumentsInitializationReads.read("", "", HttpResponse(Status.CREATED, json = Json.obj(),
+            Map(HeaderNames.LOCATION -> Seq("/foo"))))
+
+          actualResult mustBe expectedResult
+        }
+      }
+
+      "the location header is NOT returned" must {
+
+        "return a NoLocationHeaderReturned with the value false" in {
+
+          val expectedResult = Left(NoLocationHeaderReturned)
+          val actualResult = UploadCustomsDocumentsInitializationReads.read("", "", HttpResponse(Status.CREATED, json = Json.obj(), Map()))
+
+          actualResult mustBe expectedResult
+        }
+      }
+    }
+
+    "given any other status" must {
+
+      "return a Left(UnexpectedFailure)" in {
+
+        val expectedResult = Left(UnexpectedFailure(status = Status.INTERNAL_SERVER_ERROR))
+        val actualResult = UploadCustomsDocumentsInitializationReads.read("", "", HttpResponse(Status.INTERNAL_SERVER_ERROR, ""))
+
+        actualResult mustBe expectedResult
+      }
+    }
+  }
+}

--- a/test/connectors/mocks/MockHttp.scala
+++ b/test/connectors/mocks/MockHttp.scala
@@ -14,18 +14,21 @@
  * limitations under the License.
  */
 
-package config
+package connectors.mocks
 
-import play.api.Configuration
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import org.scalamock.scalatest.MockFactory
+import play.api.libs.json.Writes
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads}
 
-import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
-@Singleton
-class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig) {
+trait MockHttp extends MockFactory {
 
-  val welshLanguageSupportEnabled: Boolean = config.getOptional[Boolean]("features.welsh-language-support").getOrElse(false)
+  val mockHttp: HttpClient = mock[HttpClient]
 
-  val uploadCustomsDocumentsUrl: String = servicesConfig.baseUrl("upload-customs-documents-frontend")
-
+  def setupMockHttpPost[I, O](url: String, model: I)(response: O): Unit = {
+    (mockHttp.POST(_: String, _: I, _: Seq[(String, String)])(_: Writes[I],_: HttpReads[O], _: HeaderCarrier, _: ExecutionContext))
+      .expects(url, model, *, *, *, *, *)
+      .returns(Future.successful(response))
+  }
 }

--- a/test/utils/LogCapturing.scala
+++ b/test/utils/LogCapturing.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
+import ch.qos.logback.core.read.ListAppender
+import play.api.LoggerLike
+
+import scala.collection.JavaConverters._
+
+trait LogCapturing {
+
+  def withCaptureOfLoggingFrom(logger: LogbackLogger)(body: (=> List[ILoggingEvent]) => Unit) {
+    val appender = new ListAppender[ILoggingEvent]()
+    appender.setContext(logger.getLoggerContext)
+    appender.start()
+    logger.addAppender(appender)
+    logger.setLevel(Level.ALL)
+    logger.setAdditive(true)
+    body(appender.list.asScala.toList)
+  }
+
+  def withCaptureOfLoggingFrom(logger: LoggerLike)(body: (=> List[ILoggingEvent]) => Unit) {
+    withCaptureOfLoggingFrom(logger.logger.asInstanceOf[LogbackLogger])(body)
+  }
+}

--- a/test/utils/LoggerUtilSpec.scala
+++ b/test/utils/LoggerUtilSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import ch.qos.logback.classic.Level
+import org.scalatestplus.play.PlaySpec
+
+class LoggerUtilSpec extends PlaySpec with LogCapturing {
+
+  object TestInstanceWithLogging extends LoggerUtil {
+
+    def generateSomeLogs() = {
+      logger.debug("debug-bar")
+      logger.info("info-bar")
+      logger.warn("warn-bar")
+      logger.error("error-bar")
+    }
+  }
+
+
+  "LoggerUtil" must {
+
+    "Provide a logger which" must {
+
+      "have the correct underlying logger for the class" in {
+
+        TestInstanceWithLogging.logger.logger.getName mustBe "application.TestInstanceWithLogging"
+      }
+
+      Seq(Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR) foreach { level =>
+
+        s"output the correct $level level log and prefix with the class name" in {
+
+          withCaptureOfLoggingFrom(TestInstanceWithLogging.logger) { logs =>
+
+            TestInstanceWithLogging.generateSomeLogs()
+
+            logs.find(_.getLevel == level) match {
+              case Some(value) => value.getMessage mustBe s"[TestInstanceWithLogging] ${level.toString.toLowerCase}-bar"
+              case None => fail(s"Could not find $level message")
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently just sends pure JSON through - which we may enter via the FE in a text books.

I added a TODO, as we could copy over the initialisation models from the frontend and construct a model to send as the request instead.